### PR TITLE
Send forms with integrated email API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=username
+SMTP_PASS=password
+SMTP_FROM=from@example.com
+SMTP_TO=to@example.com

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ npm install
 npm start
 ```
 
+Pour envoyer les formulaires par email, un petit serveur Express est inclus.
+Créez un fichier `.env` inspiré de `.env.example` puis lancez :
+
+```
+node server.js
+```
+
 ## Fonctionnalités à venir
 
 - Sur la page d'accueil, un formulaire permettra à l'utilisateur.ice d'entrer sa plaque d'immatriculation, ce qui permettra de détecter à quel type de véhicule elle correspond, pour ensuite voir les pièces détachées actuellement disponibles pour ce véhicule.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
     "react-router-dom": "^6.14.2",
     "react-scripts": "5.0.1",
     "sass": "^1.88.0",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "nodemailer": "^6.9.1",
+    "dotenv": "^16.0.3"
   },
   "engines": {
     "node": "14.x"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const nodemailer = require('nodemailer');
+const cors = require('cors');
+require('dotenv').config();
+
+const app = express();
+const port = process.env.PORT || 5000;
+
+app.use(cors());
+app.use(express.json());
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: parseInt(process.env.SMTP_PORT || '587', 10),
+  secure: process.env.SMTP_SECURE === 'true',
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS,
+  },
+});
+
+app.post('/send-email', async (req, res) => {
+  const { subject, text } = req.body;
+  const mailOptions = {
+    from: process.env.SMTP_FROM,
+    to: process.env.SMTP_TO,
+    subject,
+    text,
+  };
+  try {
+    await transporter.sendMail(mailOptions);
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false });
+  }
+});
+
+app.listen(port, () => console.log(`Server listening on port ${port}`));

--- a/src/CarSell/CarSell.js
+++ b/src/CarSell/CarSell.js
@@ -11,11 +11,25 @@ function CarSell() {
     const [firstCirculationDate, setFirstCirculationDate] = useState('');
     const [kilometers, setKilometers] = useState('');
     const [description, setDescription] = useState('');
+    const [status, setStatus] = useState('');
 
-    const handleSubmit = (e) => {
+    const handleSubmit = async (e) => {
         e.preventDefault();
-        const body = `Nom et Prénom: ${name}\nEmail: ${mail}\nTéléphone: ${phone}\nType de véhicule: ${vehicleType}\nImmatriculation: ${registration}\nDate de première mise en circulation: ${firstCirculationDate}\nKilomètres au compteur: ${kilometers}\nDescription du véhicule et de son état: ${description}`;
-        window.location.href = `mailto:test@gmail.com?subject=Demande de reprise de véhicule&body=${encodeURIComponent(body)}`;
+        const text = `Nom et Prénom: ${name}\nEmail: ${mail}\nTéléphone: ${phone}\nType de véhicule: ${vehicleType}\nImmatriculation: ${registration}\nDate de première mise en circulation: ${firstCirculationDate}\nKilomètres au compteur: ${kilometers}\nDescription du véhicule et de son état: ${description}`;
+        try {
+            const res = await fetch('/send-email', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ subject: 'Demande de reprise de véhicule', text }),
+            });
+            if (res.ok) {
+                setStatus('Votre demande a bien été envoyée.');
+            } else {
+                setStatus("Erreur lors de l'envoi de votre demande.");
+            }
+        } catch (err) {
+            setStatus("Erreur lors de l'envoi de votre demande.");
+        }
     };
 
     return (
@@ -62,6 +76,7 @@ function CarSell() {
                             </label>
                             <input type="submit" value="Envoyer la demande" />
                         </form>
+                        {status && <p className='status'>{status}</p>}
                     </div>
                 </div>
             </div>

--- a/src/PartSearch/PartSearch.js
+++ b/src/PartSearch/PartSearch.js
@@ -7,7 +7,6 @@ import { ReactComponent as Cash } from '../assets/cash.svg';
 import { ReactComponent as Check } from '../assets/check.svg';
 import { ReactComponent as CreditCard } from '../assets/credit-card.svg';
 
-
 function PartSearch() {
     const [name, setName] = useState('');
     const [mail, setMail] = useState('');
@@ -17,13 +16,26 @@ function PartSearch() {
     const [registration, setRegistration] = useState('');
     const [parts, setParts] = useState('');
     const [details, setDetails] = useState('');
+    const [status, setStatus] = useState('');
 
-    const handleSubmit = (e) => {
+    const handleSubmit = async (e) => {
         e.preventDefault();
-        const body = `Nom et Prénom: ${name}\nEmail: ${mail}\nTéléphone: ${phone}\nEntreprise: ${company}\nDésignation courante du véhicule: ${designation}\nImmatriculation: ${registration}\nPièce(s) recherchée(s): ${parts}\nPrécisions: ${details}`;
-        window.location.href = `mailto:test@gmail.com?subject=Demande de recherche de pièce&body=${encodeURIComponent(body)}`;
+        const text = `Nom et Prénom: ${name}\nEmail: ${mail}\nTéléphone: ${phone}\nEntreprise: ${company}\nDésignation courante du véhicule: ${designation}\nImmatriculation: ${registration}\nPièce(s) recherchée(s): ${parts}\nPrécisions: ${details}`;
+        try {
+            const res = await fetch('/send-email', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ subject: 'Demande de recherche de pièce', text }),
+            });
+            if (res.ok) {
+                setStatus('Votre demande a bien été envoyée.');
+            } else {
+                setStatus("Erreur lors de l'envoi de votre demande.");
+            }
+        } catch (err) {
+            setStatus("Erreur lors de l'envoi de votre demande.");
+        }
     };
-
 
     return (
         <div className="part-search">
@@ -68,6 +80,7 @@ function PartSearch() {
                         </label>
                         <input type="submit" value="Envoyer la demande" />
                     </form>
+                    {status && <p className='status'>{status}</p>}
                     <div className='info'>
                         <p style={{marginBottom: '6px'}}>Pour faire une demande par téléphone:</p>
                         <div className='info__line'>


### PR DESCRIPTION
## Summary
- add a small Express server using nodemailer
- replace `mailto:` links with `fetch` calls in CarSell and PartSearch
- document server usage in README
- provide `.env.example` for mail settings

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa0092cc08333af75978dd65131e3